### PR TITLE
setup.py: remove `install_requires` `pathlib`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     test_suite='pytest',
     tests_require=['pytest','creme','scipy','numpy'],
     include_package_data=True,
-    install_requires=["wheel","pathlib"],
+    install_requires=["wheel"],
     entry_points={
         "console_scripts": [
             "momentum=momentum.__main__:main",


### PR DESCRIPTION
This breaks `poetry add momentum` and other proper dependency solvers, who try to install `pathlib` via pip -- which fails on Python 3.6+ ([which already includes `pathlib.py`, and conflict with which prevents reinstallation](https://docs.python.org/3/whatsnew/3.6.html#whatsnew36-pep519)):


```
 • Installing pathlib (1.0.1): Failed

  EnvCommandError

  Command ['...packagepath.../.venv/bin/pip', 'install', '--no-deps', 'file:///Users/Andrew/Library/Caches/pypoetry/artifacts/72/1a/9b/1572941a27e8e9d368aaedf675fd453fc64445eda7734369c0611ed020/pathlib-1.0.1.tar.gz'] errored with the following return code 1, and output:
  Processing /Users/Andrew/Library/Caches/pypoetry/artifacts/72/1a/9b/1572941a27e8e9d368aaedf675fd453fc64445eda7734369c0611ed020/pathlib-1.0.1.tar.gz
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: ...packagepath.../.venv/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/n7/btm17_wx4qbd75mnb8jvst6w0000gn/T/pip-req-build-d7gviwss/setup.py'"'"'; __file__='"'"'/private/var/folders/n7/btm17_wx4qbd75mnb8jvst6w0000gn/T/pip-req-build-d7gviwss/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/n7/btm17_wx4qbd75mnb8jvst6w0000gn/T/pip-pip-egg-info-306u8_o7
         cwd: /private/var/folders/n7/btm17_wx4qbd75mnb8jvst6w0000gn/T/pip-req-build-d7gviwss/
    Complete output (39 lines):
    running egg_info
    creating /private/var/folders/n7/btm17_wx4qbd75mnb8jvst6w0000gn/T/pip-pip-egg-info-306u8_o7/pathlib.egg-info
    writing /private/var/folders/n7/btm17_wx4qbd75mnb8jvst6w0000gn/T/pip-pip-egg-info-306u8_o7/pathlib.egg-info/PKG-INFO
    writing dependency_links to /private/var/folders/n7/btm17_wx4qbd75mnb8jvst6w0000gn/T/pip-pip-egg-info-306u8_o7/pathlib.egg-info/dependency_links.txt
    writing top-level names to /private/var/folders/n7/btm17_wx4qbd75mnb8jvst6w0000gn/T/pip-pip-egg-info-306u8_o7/pathlib.egg-info/top_level.txt
    writing manifest file '/private/var/folders/n7/btm17_wx4qbd75mnb8jvst6w0000gn/T/pip-pip-egg-info-306u8_o7/pathlib.egg-info/SOURCES.txt'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/n7/btm17_wx4qbd75mnb8jvst6w0000gn/T/pip-req-build-d7gviwss/setup.py", line 6, in <module>
        setup(
      File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 966, in run_commands
        self.run_command(cmd)
      File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "...packagepath.../.venv/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 299, in run
        self.find_sources()
      File "...packagepath.../.venv/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 306, in find_sources
        mm.run()
      File "...packagepath.../.venv/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 541, in run
        self.add_defaults()
      File "...packagepath.../.venv/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 581, in add_defaults
        rcfiles = list(walk_revctrl())
      File "...packagepath.../.venv/lib/python3.9/site-packages/setuptools/command/sdist.py", line 18, in walk_revctrl
        for item in ep.load()(dirname):
      File "...packagepath.../.venv/lib/python3.9/site-packages/setuptools_scm/integration.py", line 69, in find_files
        for ep in iter_entry_points("setuptools_scm.files_command"):
      File "...packagepath.../.venv/lib/python3.9/site-packages/setuptools_scm/utils.py", line 147, in iter_entry_points
        all_eps = entry_points()
      File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/metadata.py", line 562, in entry_points
        ordered = sorted(eps, key=by_group)
      File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/metadata.py", line 560, in <genexpr>
        dist.entry_points for dist in distributions())
      File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/metadata.py", line 261, in entry_points
        return EntryPoint._from_text(self.read_text('entry_points.txt'))
      File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/metadata.py", line 511, in read_text
        return self._path.joinpath(filename).read_text(encoding='utf-8')
    AttributeError: 'PosixPath' object has no attribute 'read_text'
    ----------------------------------------
  WARNING: Discarding file:///Users/Andrew/Library/Caches/pypoetry/artifacts/72/1a/9b/1572941a27e8e9d368aaedf675fd453fc64445eda7734369c0611ed020/pathlib-1.0.1.tar.gz. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```